### PR TITLE
Backport phonon build fix from 4.9 branch

### DIFF
--- a/org.kde.Sdk.json
+++ b/org.kde.Sdk.json
@@ -602,7 +602,8 @@
             "name": "phonon",
             "config-opts": ["-DENABLE_TESTING=OFF", "-DCMAKE_INSTALL_LIBDIR=lib", "-DPHONON_BUILD_PHONON4QT5=ON"],
             "buildsystem": "cmake-ninja",
-            "sources": [ { "type": "git", "url": "git://anongit.kde.org/phonon.git", "branch": "v4.9.0" } ]
+            "sources": [ { "type": "git", "url": "git://anongit.kde.org/phonon.git", "branch": "v4.9.0" },
+                         { "type": "patch", "path": "phonon-use-cmake-variables-to-check-if-QtDbus-is-enabled.patch" } ]
         },
         {
             "name": "knotifications",

--- a/phonon-use-cmake-variables-to-check-if-QtDbus-is-enabled.patch
+++ b/phonon-use-cmake-variables-to-check-if-QtDbus-is-enabled.patch
@@ -1,0 +1,47 @@
+From 543183aa844a27869c7fc46957ff097c155d6575 Mon Sep 17 00:00:00 2001
+From: Takahiro Hashimoto <kenya888@gmail.com>
+Date: Tue, 25 Oct 2016 09:22:35 +0900
+Subject: [PATCH] use cmake variables to check if QtDbus is enabled
+
+BUG: 368948
+REVIEW: 129256
+---
+ phonon/CMakeLists.txt      | 2 +-
+ phonon/phononconfig_p.h.in | 7 -------
+ 2 files changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/phonon/CMakeLists.txt b/phonon/CMakeLists.txt
+index e6dfcb78..f9ae09e5 100644
+--- a/phonon/CMakeLists.txt
++++ b/phonon/CMakeLists.txt
+@@ -12,7 +12,7 @@ endif (PHONON_BUILD_EXPERIMENTAL)
+ 
+ # ------------------------ Configure File QMake Style ------------------------ #
+ 
+-if (PHONON_NO_DBUS)
++if (PHONON_NO_DBUS OR NOT QT_QTDBUS_FOUND)
+     set(PHONON_NO_DBUS_DEFINE "#define PHONON_NO_DBUS")
+ else()
+     set(PHONON_NO_DBUS_DEFINE "/* #undef PHONON_NO_DBUS */")
+diff --git a/phonon/phononconfig_p.h.in b/phonon/phononconfig_p.h.in
+index 63f2305f..b3976263 100644
+--- a/phonon/phononconfig_p.h.in
++++ b/phonon/phononconfig_p.h.in
+@@ -3,14 +3,7 @@
+ #ifndef PHONONCONFIG_H_P
+ #define PHONONCONFIG_H_P
+ 
+-#include <QtCore/qfeatures.h>
+-
+ /** Whether to build with D-Bus support */
+ $${PHONON_NO_DBUS_DEFINE}
+ 
+-/** If QT_NO_DBUS is defined, always set PHONON_NO_DBUS */
+-#if !defined(PHONON_NO_DBUS) && defined(QT_NO_DBUS)
+-#define PHONON_NO_DBUS 1
+-#endif
+-
+ #endif // PHONONCONFIG_H_P
+-- 
+2.13.5
+


### PR DESCRIPTION
We import this:
https://github.com/KDE/phonon/commit/543183aa844a27869c7fc46957ff097c155d6575

Into the 4.9.0 commit in order to fix the build, because otherwise we get this build failure in
phonen:

In file included from /run/build-runtime/phonon/phonon/audiooutput_p.h:28:0,
                 from /run/build-runtime/phonon/phonon/audiooutput.cpp:23:
/run/build-runtime/phonon/phonon/phononconfig_p.h:6:30: fatal error: QtCore/qfeatures.h: No such file or directory
 #include <QtCore/qfeatures.h>
                              ^
compilation terminated.