### PR TITLE
Automatically download GNOME platform and matching themes

### DIFF
--- a/org.kde.Sdk.json
+++ b/org.kde.Sdk.json
@@ -29,6 +29,7 @@
             "directory": "share/runtime/lib/plugins/",
             "subdirectories": true,
             "no-autodownload": true,
+            "download-if": "active-gtk-theme",
             "version": "5.10",
             "merge-dirs": "styles"
         },
@@ -37,6 +38,7 @@
             "subdirectories": true,
             "no-autodownload": true,
             "version": "5.10",
+            "download-if": "on-gnome-platform",
             "merge-dirs": "platformthemes"
         }
     },


### PR DESCRIPTION
Depends upon https://github.com/flatpak/flatpak/pull/1436

Will also want to backport this to the 5.9 branch of course.