### PR TITLE
Don't load Sdk extensions in the Platform

### DIFF
--- a/org.kde.Sdk.json
+++ b/org.kde.Sdk.json
@@ -13,10 +13,12 @@
         "org.freedesktop.Platform.Timezones",
         "org.freedesktop.Platform.GStreamer",
         "org.freedesktop.Platform.Icontheme",
-        "org.freedesktop.Sdk.Extension",
         "org.freedesktop.Platform.VAAPI.Intel",
         "org.freedesktop.Platform.html5-codecs",
         "org.gtk.Gtk3theme"
+    ],
+    "inherit-sdk-extensions": [
+        "org.freedesktop.Sdk.Extension"
     ],
     "add-extensions": {
         "org.kde.Sdk.Docs" : {


### PR DESCRIPTION
 When trying to run an app with the 5.12 KDE runtime, I always get this:

```
bwrap: Can't mkdir /usr/lib/sdk: Read-only file system
error: ldconfig failed, exit status 256
```

Seems to be related to this: https://gitlab.gnome.org/GNOME/gnome-sdk-images/issues/10

I haven’t tried this fix (don’t have the hours needed for that currently in disposition), but I think it should work.